### PR TITLE
Lightning compatibility fix

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -16,7 +16,10 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+try:
+    from pytorch_lightning.utilities import rank_zero_only
+except:
+    from pytorch_lightning.utilities.distributed import rank_zero_only
 from omegaconf import ListConfig
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config


### PR DESCRIPTION
Hello,

I'm unsure if this repository is still maintained, but I had to resolve this on my own so I figured I'd open a PR as well in case it still is maintained.

Due to a change in lightning's tree structure there will be an import failure if someone has to upgrade lighting, which was the case for me.
This commit just changes that one import line and attempt to import assuming it's the new version, and if it fails it'll fall back to trying to import the old one.